### PR TITLE
Feature/smart complete

### DIFF
--- a/cmd/goto.go
+++ b/cmd/goto.go
@@ -261,7 +261,6 @@ func main() {
 	if recall {
 		if t, ok := markers[recallMarkerName]; ok {
 			destDir := t.Path
-			incrementUsage(recallMarkerName, markers)
 			err := setRecall(markers)
 			if err != nil {
 				fmt.Println("error updating recall dest:", err)

--- a/cmd/goto.go
+++ b/cmd/goto.go
@@ -22,14 +22,14 @@ var names bool
 
 const recallMarkerName = "previous"
 
-func setRecall(markers map[string]string) error {
+func setRecall(markers marker.MarkerMap) error {
 	curDir, _ := os.Getwd()
 
 	// Errors are ignored here because it is okay if previous marker doesn't exist.
 	// We'll just make it in the marker.Add() call below
 	_ = marker.Delete(recallMarkerName, markers)
 
-	// Error is discarded here because the marker is guarunteed to not already exist
+	// Error is discarded here because the marker is guaranteed to not already exist
 	// by the previous call to marker.Delete()
 	markers, _ = marker.Add(recallMarkerName, curDir, markers)
 
@@ -108,7 +108,7 @@ func migrateOldMarkers(oldPath, newPath string) error {
 	return nil
 }
 
-func sortKeys(m map[string]string) []string {
+func sortKeys(m marker.MarkerMap) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -149,7 +149,7 @@ func main() {
 
 	markers, err := marker.LoadMarkers()
 	if markers == nil {
-		markers = make(map[string]string)
+		markers = make(marker.MarkerMap)
 	}
 
 	if err != nil {
@@ -222,7 +222,7 @@ func main() {
 
 	if recall {
 		if t, ok := markers[recallMarkerName]; ok {
-			destDir := t
+			destDir := t.Path
 			err := setRecall(markers)
 			if err != nil {
 				fmt.Println("error updating recall dest:", err)
@@ -236,7 +236,7 @@ func main() {
 	}
 
 	if t, ok := markers[target]; ok {
-		destDir := t
+		destDir := t.Path
 		err := setRecall(markers)
 		if err != nil {
 			fmt.Println("error updating recall dest:", err)

--- a/cmd/goto.go
+++ b/cmd/goto.go
@@ -104,12 +104,15 @@ func migrateOldMarkers(oldPath, newPath string) error {
 	return nil
 }
 
-func incrementUsage(name string, markers marker.MarkerMap) marker.MarkerMap {
+func incrementUsage(name string, markers marker.MarkerMap) {
+	if name == recallMarkerName {
+		return
+	}
+
 	if m, ok := markers[name]; ok {
 		m.Usage++
 		markers[name] = m
 	}
-	return markers
 }
 
 func sortKeysAlpha(m marker.MarkerMap) []string {
@@ -258,7 +261,7 @@ func main() {
 	if recall {
 		if t, ok := markers[recallMarkerName]; ok {
 			destDir := t.Path
-			markers = incrementUsage(recallMarkerName, markers)
+			incrementUsage(recallMarkerName, markers)
 			err := setRecall(markers)
 			if err != nil {
 				fmt.Println("error updating recall dest:", err)
@@ -267,13 +270,14 @@ func main() {
 			fmt.Println(destDir)
 			os.Exit(0)
 		}
+
 		fmt.Println("No recall position")
 		os.Exit(1)
 	}
 
 	if t, ok := markers[target]; ok {
 		destDir := t.Path
-		markers = incrementUsage(target, markers)
+		incrementUsage(target, markers)
 		err := setRecall(markers)
 		if err != nil {
 			fmt.Println("error updating recall dest:", err)

--- a/cmd/goto.go
+++ b/cmd/goto.go
@@ -19,25 +19,21 @@ var recall bool
 
 var printing bool
 var names bool
+var sortOption string
 
 const recallMarkerName = "previous"
 
 func setRecall(markers marker.MarkerMap) error {
 	curDir, _ := os.Getwd()
 
-	// Errors are ignored here because it is okay if previous marker doesn't exist.
-	// We'll just make it in the marker.Add() call below
-	_ = marker.Delete(recallMarkerName, markers)
-
-	// Error is discarded here because the marker is guaranteed to not already exist
-	// by the previous call to marker.Delete()
-	markers, _ = marker.Add(recallMarkerName, curDir, markers)
-
-	err := marker.SaveMarkers(markers)
-	if err != nil {
-		return err
+	existingUsage := 0
+	if recallMarker, ok := markers[recallMarkerName]; ok {
+		existingUsage = recallMarker.Usage
 	}
-	return nil
+
+	markers[recallMarkerName] = marker.Marker{Path: curDir, Usage: existingUsage}
+
+	return marker.SaveMarkers(markers)
 }
 
 func ensureDotFiles() error {
@@ -108,12 +104,40 @@ func migrateOldMarkers(oldPath, newPath string) error {
 	return nil
 }
 
-func sortKeys(m marker.MarkerMap) []string {
+func incrementUsage(name string, markers marker.MarkerMap) marker.MarkerMap {
+	if m, ok := markers[name]; ok {
+		m.Usage++
+		markers[name] = m
+	}
+	return markers
+}
+
+func sortKeysAlpha(m marker.MarkerMap) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	return keys
+}
+
+func sortKeysUsage(m marker.MarkerMap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		left := m[keys[i]]
+		right := m[keys[j]]
+
+		if left.Usage == right.Usage {
+			return keys[i] < keys[j]
+		}
+
+		return left.Usage > right.Usage
+	})
+
 	return keys
 }
 
@@ -145,6 +169,7 @@ func main() {
 
 	flag.BoolVar(&names, "names", false, "Prints available marker names")
 	flag.BoolVar(&names, "n", false, "Prints available marker names")
+	flag.StringVar(&sortOption, "sort", "alpha", "Sort order for --list: alpha or usage")
 	flag.Parse()
 
 	markers, err := marker.LoadMarkers()
@@ -165,7 +190,7 @@ func main() {
 	}
 
 	if names {
-		sortedKeys := sortKeys(markers)
+		sortedKeys := sortKeysUsage(markers)
 		for _, key := range sortedKeys {
 			fmt.Println(key)
 		}
@@ -175,12 +200,22 @@ func main() {
 	target := os.Args[len(os.Args)-1]
 
 	if listing {
+		if sortOption != "alpha" && sortOption != "usage" {
+			fmt.Printf("invalid sort option: %s\n", sortOption)
+			os.Exit(1)
+		}
+
 		if len(markers) == 0 {
 			fmt.Println("No markers exist! Add one with the -a flag!")
 			os.Exit(0)
 		}
 
-		fmt.Print(ui.FormatListing(markers))
+		keys := sortKeysAlpha(markers)
+		if sortOption == "usage" {
+			keys = sortKeysUsage(markers)
+		}
+
+		fmt.Print(ui.FormatListing(markers, keys))
 		os.Exit(0)
 	}
 
@@ -223,6 +258,7 @@ func main() {
 	if recall {
 		if t, ok := markers[recallMarkerName]; ok {
 			destDir := t.Path
+			markers = incrementUsage(recallMarkerName, markers)
 			err := setRecall(markers)
 			if err != nil {
 				fmt.Println("error updating recall dest:", err)
@@ -237,6 +273,7 @@ func main() {
 
 	if t, ok := markers[target]; ok {
 		destDir := t.Path
+		markers = incrementUsage(target, markers)
 		err := setRecall(markers)
 		if err != nil {
 			fmt.Println("error updating recall dest:", err)

--- a/cmd/goto_test.go
+++ b/cmd/goto_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/nathanmazzapica/goto/internal/ui"
 )
 
-func createTestMarkers(n int) map[string]string {
-	markers := make(map[string]string, n)
+func createTestMarkers(n int) marker.MarkerMap {
+	markers := make(marker.MarkerMap, n)
 	names := []string{"zulu", "alpha", "mike", "bravo", "yankee", "charlie",
 		"xray", "delta", "whiskey", "echo", "victor", "foxtrot", "uniform",
 		"golf", "tango", "hotel", "sierra", "india", "romeo", "juliet",
 		"quebec", "kilo", "papa", "lima", "oscar", "november"}
 
 	for i := 0; i < n && i < len(names); i++ {
-		markers[names[i]] = "/some/path/" + names[i]
+		markers[names[i]] = marker.Marker{Path: "/some/path/" + names[i]}
 	}
 	return markers
 }
@@ -107,6 +107,7 @@ func TestMigrateOldMarkers_OldFileEmpty(t *testing.T) {
 	}
 }
 
+// TestMigrateOldMarkers_MigratesContent ensures that markers from an old .markers file are properly migrated to the new .markers destination
 func TestMigrateOldMarkers_MigratesContent(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldPath := filepath.Join(tmpDir, ".markers")
@@ -209,7 +210,7 @@ func TestMigrateOldMarkers_MigratesWhenNewFileEmpty(t *testing.T) {
 	}
 }
 
-func writeMarkers(t *testing.T, home string, markers map[string]string) {
+func writeMarkers(t *testing.T, home string, markers marker.MarkerMap) {
 	t.Helper()
 	configDir := filepath.Join(home, ".config", "goto")
 	if err := os.MkdirAll(configDir, 0o700); err != nil {
@@ -220,9 +221,26 @@ func writeMarkers(t *testing.T, home string, markers map[string]string) {
 	}
 }
 
-func runGoto(t *testing.T, home string, args ...string) (string, error) {
+// buildGotoBinary builds the CLI once for the test run to avoid repeated
+// go run compiles. Longer term, refactor CLI logic into a callable function to
+// test without spawning a process.
+func buildGotoBinary(t *testing.T) (string, func()) {
 	t.Helper()
-	cmd := exec.Command("go", append([]string{"run", "./goto.go"}, args...)...)
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "goto-test-bin")
+	cmd := exec.Command("go", "build", "-o", binaryPath, "./goto.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build goto binary: %v, output: %s", err, string(out))
+	}
+	cleanup := func() {
+		_ = os.Remove(binaryPath)
+	}
+	return binaryPath, cleanup
+}
+
+func runGoto(t *testing.T, binaryPath, home string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binaryPath, args...)
 	cmd.Env = append(os.Environ(), "HOME="+home)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
@@ -231,15 +249,18 @@ func runGoto(t *testing.T, home string, args ...string) (string, error) {
 func TestNamesFlagPrintsSortedMarkersIncludingSpecials(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	markers := map[string]string{
-		"space name":       "/path/space name",
-		"marker-with-dash": "/path/dash",
-		"alpha":            "/path/alpha",
-		"unicøde":          "/path/unicøde",
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
+
+	markers := marker.MarkerMap{
+		"space name":       {Path: "/path/space name"},
+		"marker-with-dash": {Path: "/path/dash"},
+		"alpha":            {Path: "/path/alpha"},
+		"unicøde":          {Path: "/path/unicøde"},
 	}
 	writeMarkers(t, home, markers)
 
-	out, err := runGoto(t, home, "--names")
+	out, err := runGoto(t, binaryPath, home, "--names")
 	if err != nil {
 		t.Fatalf("goto --names failed: %v, output: %s", err, out)
 	}
@@ -256,9 +277,12 @@ func TestNamesFlagPrintsSortedMarkersIncludingSpecials(t *testing.T) {
 func TestNamesFlagHandlesEmptyMarkers(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	writeMarkers(t, home, map[string]string{})
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
 
-	out, err := runGoto(t, home, "--names")
+	writeMarkers(t, home, marker.MarkerMap{})
+
+	out, err := runGoto(t, binaryPath, home, "--names")
 	if err != nil {
 		t.Fatalf("goto --names failed on empty markers: %v, output: %s", err, out)
 	}
@@ -271,14 +295,17 @@ func TestNamesFlagHandlesEmptyMarkers(t *testing.T) {
 func TestListOutputsBoxDrawingWithWidths(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	markers := map[string]string{
-		"longnameeeee": "/very/long/path/here",
-		"short":        "/s",
-		"special name": "/tmp/special path",
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
+
+	markers := marker.MarkerMap{
+		"longnameeeee": {Path: "/very/long/path/here"},
+		"short":        {Path: "/s"},
+		"special name": {Path: "/tmp/special path"},
 	}
 	writeMarkers(t, home, markers)
 
-	out, err := runGoto(t, home, "--list")
+	out, err := runGoto(t, binaryPath, home, "--list")
 	if err != nil {
 		t.Fatalf("goto --list failed: %v, output: %s", err, out)
 	}
@@ -293,8 +320,10 @@ func TestListOutputsBoxDrawingWithWidths(t *testing.T) {
 func TestAddRejectsRecallMarkerName(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
 
-	out, err := runGoto(t, home, "--add", recallMarkerName)
+	out, err := runGoto(t, binaryPath, home, "--add", recallMarkerName)
 	if err == nil {
 		t.Fatalf("expected failure when adding reserved marker name, got success with output: %s", out)
 	}

--- a/cmd/goto_test.go
+++ b/cmd/goto_test.go
@@ -26,6 +26,38 @@ func createTestMarkers(n int) marker.MarkerMap {
 	return markers
 }
 
+func sortKeysAlphaTest(m marker.MarkerMap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortKeysUsageTest(m marker.MarkerMap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		left := m[keys[i]]
+		right := m[keys[j]]
+
+		if left.Usage == right.Usage {
+			return keys[i] < keys[j]
+		}
+		return left.Usage > right.Usage
+	})
+
+	return keys
+}
+
+func sortKeys(m marker.MarkerMap) []string {
+	return sortKeysAlphaTest(m)
+}
+
 func BenchmarkSortKeys(b *testing.B) {
 	markers := createTestMarkers(10)
 	for i := 0; i < b.N; i++ {
@@ -253,10 +285,10 @@ func TestNamesFlagPrintsSortedMarkersIncludingSpecials(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	markers := marker.MarkerMap{
-		"space name":       {Path: "/path/space name"},
-		"marker-with-dash": {Path: "/path/dash"},
-		"alpha":            {Path: "/path/alpha"},
-		"unicøde":          {Path: "/path/unicøde"},
+		"space name":       {Path: "/path/space name", Usage: 3},
+		"marker-with-dash": {Path: "/path/dash", Usage: 3},
+		"alpha":            {Path: "/path/alpha", Usage: 1},
+		"unicøde":          {Path: "/path/unicøde", Usage: 0},
 	}
 	writeMarkers(t, home, markers)
 
@@ -265,8 +297,7 @@ func TestNamesFlagPrintsSortedMarkersIncludingSpecials(t *testing.T) {
 		t.Fatalf("goto --names failed: %v, output: %s", err, out)
 	}
 
-	expectedKeys := []string{"alpha", "marker-with-dash", "space name", "unicøde"}
-	sort.Strings(expectedKeys)
+	expectedKeys := sortKeysUsageTest(markers)
 	expected := strings.Join(expectedKeys, "\n") + "\n"
 
 	if out != expected {
@@ -310,7 +341,8 @@ func TestListOutputsBoxDrawingWithWidths(t *testing.T) {
 		t.Fatalf("goto --list failed: %v, output: %s", err, out)
 	}
 
-	expected := ui.FormatListing(markers)
+	keys := sortKeysAlphaTest(markers)
+	expected := ui.FormatListing(markers, keys)
 
 	if out != expected {
 		t.Fatalf("unexpected list output.\nexpected:\n%q\ngot:\n%q", expected, out)
@@ -331,5 +363,89 @@ func TestAddRejectsRecallMarkerName(t *testing.T) {
 	expected := fmt.Sprintf("%s is reserved for tp --recall\n", recallMarkerName)
 	if !strings.HasPrefix(out, expected) {
 		t.Fatalf("unexpected output when adding reserved marker. expected prefix %q, got %q", expected, out)
+	}
+}
+
+func TestListSortUsageOrdersByUsage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
+
+	markers := marker.MarkerMap{
+		"alpha": {Path: "/path/alpha", Usage: 1},
+		"beta":  {Path: "/path/beta", Usage: 3},
+		"gamma": {Path: "/path/gamma", Usage: 3},
+		"delta": {Path: "/path/delta", Usage: 0},
+	}
+	writeMarkers(t, home, markers)
+
+	out, err := runGoto(t, binaryPath, home, "--list", "--sort", "usage")
+	if err != nil {
+		t.Fatalf("goto --list --sort usage failed: %v, output: %s", err, out)
+	}
+
+	keys := sortKeysUsageTest(markers)
+	expected := ui.FormatListing(markers, keys)
+
+	if out != expected {
+		t.Fatalf("unexpected usage-sorted list output.\nexpected:\n%q\ngot:\n%q", expected, out)
+	}
+}
+
+func TestNavigationIncrementsUsage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
+
+	markers := marker.MarkerMap{
+		"alpha": {Path: "/path/alpha", Usage: 2},
+	}
+	writeMarkers(t, home, markers)
+
+	out, err := runGoto(t, binaryPath, home, "alpha")
+	if err != nil {
+		t.Fatalf("goto navigation failed: %v, output: %s", err, out)
+	}
+
+	loaded, loadErr := marker.LoadMarkers()
+	if loadErr != nil {
+		t.Fatalf("failed to reload markers: %v", loadErr)
+	}
+
+	if got := loaded["alpha"].Usage; got != 3 {
+		t.Fatalf("expected usage to increment to 3, got %d", got)
+	}
+}
+
+func TestPrintIncrementsUsage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binaryPath, cleanup := buildGotoBinary(t)
+	t.Cleanup(cleanup)
+
+	markers := marker.MarkerMap{
+		"alpha": {Path: "/path/alpha", Usage: 5},
+	}
+	writeMarkers(t, home, markers)
+
+	out, err := runGoto(t, binaryPath, home, "--print", "alpha")
+	if err != nil {
+		t.Fatalf("goto --print failed: %v, output: %s", err, out)
+	}
+
+	loaded, loadErr := marker.LoadMarkers()
+	if loadErr != nil {
+		t.Fatalf("failed to reload markers: %v", loadErr)
+	}
+
+	if got := loaded["alpha"].Usage; got != 6 {
+		t.Fatalf("expected usage to increment to 6, got %d", got)
+	}
+
+	expectedOutput := "/path/alpha\n"
+	if out != expectedOutput {
+		t.Fatalf("unexpected print output. expected %q got %q", expectedOutput, out)
 	}
 }

--- a/completions/_tp
+++ b/completions/_tp
@@ -3,6 +3,8 @@
 _tp() {
 	local -a _tp_markers
 	_tp_markers=(${(f)"$(goto --names 2>/dev/null)"})
+	zstyle ':completion:*:tp:*' sort false
+	zstyle ':completion:*:goto:*' sort false
 
 	_arguments -C \
 		'(-a --add)'{-a,--add}'[Add marker]' \
@@ -11,11 +13,16 @@ _tp() {
 		'(-r --recall)'{-r,--recall}'[Return to previous directory]' \
 		'(-p --print)'{-p,--print}'[Print marker destination]:marker name:->markers' \
 		'(-n --names)'{-n,--names}'[List marker names]' \
-		'*:marker name:->default' && return 0
+		'*:marker name:->markers' && return 0
 
 	case $state in
 		(markers|default)
-			compadd -- ${_tp_markers[@]}
+			local expl matches
+			matches=(${(M)_tp_markers:#${PREFIX}*})
+			(( $#matches )) || return 1
+			_wanted markers expl 'marker' compadd -Q -U -a matches
 		;;
 	esac
 }
+
+

--- a/internal/marker/add.go
+++ b/internal/marker/add.go
@@ -1,14 +1,34 @@
 package marker
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var (
 	ErrAlreadyExists = fmt.Errorf("marker already exists")
+	ErrInvalidName   = fmt.Errorf("marker names cannot contain ':'")
+	ErrInvalidPath   = fmt.Errorf("marker paths cannot contain ':'")
 )
 
-func Add(key, path string, markers map[string]string) (map[string]string, error) {
+type Marker struct {
+	Path  string
+	Usage int
+}
+
+type MarkerMap map[string]Marker
+
+func Add(key, path string, markers MarkerMap) (MarkerMap, error) {
+	if strings.Contains(key, ":") {
+		return markers, ErrInvalidName
+	}
+
+	if strings.Contains(path, ":") {
+		return markers, ErrInvalidPath
+	}
+
 	if _, ok := markers[key]; !ok {
-		markers[key] = path
+		markers[key] = Marker{Path: path, Usage: 0}
 		return markers, nil
 	}
 

--- a/internal/marker/delete.go
+++ b/internal/marker/delete.go
@@ -6,8 +6,7 @@ var (
 	ErrDoesntExist = fmt.Errorf("marker does not exist")
 )
 
-func Delete(key string, markers map[string]string) error {
-
+func Delete(key string, markers MarkerMap) error {
 	if _, ok := markers[key]; !ok {
 		return ErrDoesntExist
 	}

--- a/internal/marker/load.go
+++ b/internal/marker/load.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
-func LoadMarkers() (map[string]string, error) {
-	markers := make(map[string]string)
+func LoadMarkers() (MarkerMap, error) {
+	markers := make(MarkerMap)
 
 	home, _ := os.UserHomeDir()
 	configPath := filepath.Join(home, ".config", "goto", ".markers")
@@ -26,13 +27,38 @@ func LoadMarkers() (map[string]string, error) {
 			continue
 		}
 
-		key, value, found := strings.Cut(pair, ":")
-		if !found {
-			// TODO: handle better?
-			fmt.Printf("error splitting pair: %s\n", pair)
-			return markers, fmt.Errorf("invalid pair: { %s }", pair)
+		fields := strings.Split(pair, ":")
+		if len(fields) != 2 && len(fields) != 3 {
+			return markers, fmt.Errorf("invalid marker entry: %s", pair)
 		}
-		markers[key] = value
+
+		name := fields[0]
+		path := fields[1]
+
+		if strings.Contains(name, ":") {
+			return markers, fmt.Errorf("invalid marker name contains ':'")
+		}
+
+		if strings.Contains(path, ":") {
+			return markers, fmt.Errorf("invalid marker path contains ':'")
+		}
+
+		usage := 0
+		if len(fields) == 3 {
+			if fields[2] == "" {
+				return markers, fmt.Errorf("invalid marker usage in entry: %s", pair)
+			}
+			parsed, parseErr := strconv.Atoi(fields[2])
+			if parseErr != nil {
+				return markers, fmt.Errorf("invalid marker usage in entry: %s", pair)
+			}
+			if parsed < 0 {
+				return markers, fmt.Errorf("marker usage cannot be negative: %s", pair)
+			}
+			usage = parsed
+		}
+
+		markers[name] = Marker{Path: path, Usage: usage}
 	}
 
 	return markers, nil

--- a/internal/marker/save.go
+++ b/internal/marker/save.go
@@ -7,11 +7,17 @@ import (
 	"strings"
 )
 
-func SaveMarkers(markers map[string]string) error {
+func SaveMarkers(markers MarkerMap) error {
 	pairs := make([]string, 0, len(markers))
 
 	for key, value := range markers {
-		joined := fmt.Sprintf("%s:%s", key, value)
+		if strings.Contains(key, ":") {
+			return fmt.Errorf("invalid marker name contains ':'")
+		}
+		if strings.Contains(value.Path, ":") {
+			return fmt.Errorf("invalid marker path contains ':'")
+		}
+		joined := fmt.Sprintf("%s:%s:%d", key, value.Path, value.Usage)
 		pairs = append(pairs, joined)
 	}
 
@@ -20,7 +26,7 @@ func SaveMarkers(markers map[string]string) error {
 	home, _ := os.UserHomeDir()
 	configPath := filepath.Join(home, ".config", "goto", ".markers")
 
-	err := os.WriteFile(configPath, data, 0600)
+	err := os.WriteFile(configPath, data, 0o600)
 
 	return err
 }

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -2,22 +2,17 @@ package ui
 
 import (
 	"fmt"
-	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/nathanmazzapica/goto/internal/marker"
 )
 
 // FormatListing returns a table of markers and destinations using box-drawing characters.
-func FormatListing(markers marker.MarkerMap) string {
+func FormatListing(markers marker.MarkerMap, keys []string) string {
 	markerWidth := len("MARKER")
 	destinationWidth := len("DESTINATION")
-
-	keys := make([]string, 0, len(markers))
-	for key := range markers {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	usageWidth := len("USAGE")
 
 	for _, key := range keys {
 		if len(key) > markerWidth {
@@ -26,17 +21,22 @@ func FormatListing(markers marker.MarkerMap) string {
 		if len(markers[key].Path) > destinationWidth {
 			destinationWidth = len(markers[key].Path)
 		}
+
+		usageLength := len(strconv.Itoa(markers[key].Usage))
+		if usageLength > usageWidth {
+			usageWidth = usageLength
+		}
 	}
 
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "┌─%s─┬─%s─┐\n", strings.Repeat("─", markerWidth), strings.Repeat("─", destinationWidth))
-	fmt.Fprintf(&builder, "│ %-*s │ %-*s │\n", markerWidth, "MARKER", destinationWidth, "DESTINATION")
-	fmt.Fprintf(&builder, "├─%s─┼─%s─┤\n", strings.Repeat("─", markerWidth), strings.Repeat("─", destinationWidth))
+	fmt.Fprintf(&builder, "┌─%s─┬─%s─┬─%s─┐\n", strings.Repeat("─", markerWidth), strings.Repeat("─", usageWidth), strings.Repeat("─", destinationWidth))
+	fmt.Fprintf(&builder, "│ %-*s │ %*s │ %-*s │\n", markerWidth, "MARKER", usageWidth, "USAGE", destinationWidth, "DESTINATION")
+	fmt.Fprintf(&builder, "├─%s─┼─%s─┼─%s─┤\n", strings.Repeat("─", markerWidth), strings.Repeat("─", usageWidth), strings.Repeat("─", destinationWidth))
 
 	for _, key := range keys {
-		fmt.Fprintf(&builder, "│ %-*s │ %-*s │\n", markerWidth, key, destinationWidth, markers[key].Path)
+		fmt.Fprintf(&builder, "│ %-*s │ %*d │ %-*s │\n", markerWidth, key, usageWidth, markers[key].Usage, destinationWidth, markers[key].Path)
 	}
 
-	fmt.Fprintf(&builder, "└─%s─┴─%s─┘\n", strings.Repeat("─", markerWidth), strings.Repeat("─", destinationWidth))
+	fmt.Fprintf(&builder, "└─%s─┴─%s─┴─%s─┘\n", strings.Repeat("─", markerWidth), strings.Repeat("─", usageWidth), strings.Repeat("─", destinationWidth))
 	return builder.String()
 }

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/nathanmazzapica/goto/internal/marker"
 )
 
 // FormatListing returns a table of markers and destinations using box-drawing characters.
-func FormatListing(markers map[string]string) string {
+func FormatListing(markers marker.MarkerMap) string {
 	markerWidth := len("MARKER")
 	destinationWidth := len("DESTINATION")
 
@@ -21,8 +23,8 @@ func FormatListing(markers map[string]string) string {
 		if len(key) > markerWidth {
 			markerWidth = len(key)
 		}
-		if len(markers[key]) > destinationWidth {
-			destinationWidth = len(markers[key])
+		if len(markers[key].Path) > destinationWidth {
+			destinationWidth = len(markers[key].Path)
 		}
 	}
 
@@ -32,7 +34,7 @@ func FormatListing(markers map[string]string) string {
 	fmt.Fprintf(&builder, "├─%s─┼─%s─┤\n", strings.Repeat("─", markerWidth), strings.Repeat("─", destinationWidth))
 
 	for _, key := range keys {
-		fmt.Fprintf(&builder, "│ %-*s │ %-*s │\n", markerWidth, key, destinationWidth, markers[key])
+		fmt.Fprintf(&builder, "│ %-*s │ %-*s │\n", markerWidth, key, destinationWidth, markers[key].Path)
 	}
 
 	fmt.Fprintf(&builder, "└─%s─┴─%s─┘\n", strings.Repeat("─", markerWidth), strings.Repeat("─", destinationWidth))


### PR DESCRIPTION
## Summary
The autocomplete will now sort options based on your most commonly used markers.

Markers now have their own type instead of just being a map[string]string. This will make future expansion easier for both human developers and AI agents. 

To further increase clarity and ease of expansion, I also added the type MarkerMap as an alias for map[string]Marker.


## AI Usage Thoughts
This tool started off as something simple that saved me a lot of time. I wrote it myself in about a day. I then thought it'd be a good testing ground for AI and I got pretty satisfactory results. The problem space is small enough that its easy to prompt an AI with a good set of constraints that keeps it on track. 

As I continue to use the tool, I run into more bumps. I design solutions to these bumps and hand the design off to OpenCode. I actually really like this workflow for a personal tool and even find myself excited at the level of personalization AI can enable in small open-source tools.

Still, understanding of the tool is important to get good results. The less direction you give the AI, the worse output you'll get, naturally. I experienced this first hand with trying to get the new usage-based autocomplete to work. It took the Codex 5.1 several iterations to finally achieve the behavior I was looking for and it ended up being a simple flag issue it kept missing.

Had I read the zsh documentation, I would have been able to spot this problem myself and fixed it quicker than the agent could have.

I think this is true in a lot of cases. AI is a great tool for speeding up development, but its very inefficient at solving small bugs (at least in my experience). Even using plan mode to try and diagnose the issue did not help so much here.

AI can speed up implementation, but without an experienced developer with understanding of the tools and problem domain to steer it, it'll quickly slow things down. Do not let AI replace your thinking and learning. Understand the frameworks and tools you ask it to work with. Not just syntax-wise, but conceptually. 

thanks for reading